### PR TITLE
Eliminating an esoteric error by valgrind, it wants to seean explicit…

### DIFF
--- a/src/json_interface.c
+++ b/src/json_interface.c
@@ -63,7 +63,7 @@ int ji_init(const char *file_name)
         return EXIT_FAILURE;
     }
     
-    file_handle  = fopen(f_name, "r");
+    file_handle  = fopen(f_name, "r\0");
     if( NULL == file_handle ) {
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
… null terminating a constant string being passed to fopen() ...