### PR TITLE
define target_link_libraries

### DIFF
--- a/libseshat/src/CMakeLists.txt
+++ b/libseshat/src/CMakeLists.txt
@@ -23,6 +23,14 @@ set_target_properties(${PROJ_LIBSESHAT}.shared PROPERTIES OUTPUT_NAME ${PROJ_LIB
 set_property(TARGET ${PROJ_LIBSESHAT} PROPERTY C_STANDARD 99)
 set_property(TARGET ${PROJ_LIBSESHAT}.shared PROPERTY C_STANDARD 99)
 
+# ----------------------------------------------------------------------------
+# Note: This is a partial solution and only covers the case required for the
+# Yocto build (ie dynamic lib). Other cases may need fixing too.
+# ----------------------------------------------------------------------------
+if (BUILD_YOCTO)
+target_link_libraries(${PROJ_LIBSESHAT}.shared m log4c rdkloggers cjson cimplog nanomsg wrp-c msgpackc trower-base64)
+endif (BUILD_YOCTO)
+
 install (TARGETS ${PROJ_LIBSESHAT} DESTINATION lib${LIB_SUFFIX})
 install (TARGETS ${PROJ_LIBSESHAT}.shared DESTINATION lib${LIB_SUFFIX})
 install (FILES libseshat.h DESTINATION include/${PROJ_LIBSESHAT})


### PR DESCRIPTION
In order to get everything in the right order on the linker command
line, external libraries need to be defined via LINK_LIBRARIES (and
not via LDFLAGS).

See similar fix recently merged to cimplog:

  https://github.com/Comcast/cimplog/commit/854c98fd5f38df102487dc78d085d610e4f8bab7

Signed-off-by: Andre McCurdy <armccurdy@gmail.com>